### PR TITLE
multiplatform path appends

### DIFF
--- a/tests/test_dynamic_environments.py
+++ b/tests/test_dynamic_environments.py
@@ -1,13 +1,16 @@
+# -*- coding: utf-8 -*
+"""Acre test suite."""
 import unittest
+from unittest import mock
 
 import acre
 
 
 class TestDynamicEnvironments(unittest.TestCase):
+    """Test acre processing of dynamic environments."""
 
     def test_parse_platform(self):
-        """Parse works for 'platform-specific environments'"""
-
+        """Parse works for 'platform-specific environments'."""
         data = {
             "A": {
                 "darwin": "darwin-path",
@@ -16,7 +19,6 @@ class TestDynamicEnvironments(unittest.TestCase):
             },
             "B": "universal"
         }
-
         result = acre.parse(data, platform_name="darwin")
         self.assertEqual(result["A"], data["A"]["darwin"])
         self.assertEqual(result["B"], data["B"])
@@ -30,8 +32,7 @@ class TestDynamicEnvironments(unittest.TestCase):
         self.assertEqual(result["B"], data["B"])
 
     def test_nesting_deep(self):
-        """Deep nested dynamic environment computes correctly"""
-
+        """Deep nested dynamic environment computes correctly."""
         data = {
             "A": "bla",
             "B": "{A}",
@@ -59,7 +60,7 @@ class TestDynamicEnvironments(unittest.TestCase):
         })
 
     def test_cycle(self):
-        """Cycle error is correctly detected in dynamic environment"""
+        """Cycle error is correctly detected in dynamic environment."""
         data = {
             "X": "{Y}",
             "Y": "{X}"
@@ -74,7 +75,7 @@ class TestDynamicEnvironments(unittest.TestCase):
         self.assertEqual(result["X"], result["Y"])
 
     def test_dynamic_keys(self):
-        """Computing dynamic keys works"""
+        """Computing dynamic keys works."""
         data = {
             "A": "D",
             "B": "C",
@@ -92,7 +93,7 @@ class TestDynamicEnvironments(unittest.TestCase):
         })
 
     def test_dynamic_keys_clash_cycle(self):
-        """Dynamic key clash cycle captured correctly"""
+        """Dynamic key clash cycle captured correctly."""
         data = {
             "foo": "foo",
             "{foo}": "bar"
@@ -105,7 +106,7 @@ class TestDynamicEnvironments(unittest.TestCase):
         acre.compute(data, allow_key_clash=True)
 
     def test_dynamic_keys_clash(self):
-        """Dynamic key clash captured correctly"""
+        """Dynamic key clash captured correctly."""
         data = {
             "A": "foo",
             "{A}": "bar",
@@ -119,28 +120,42 @@ class TestDynamicEnvironments(unittest.TestCase):
         acre.compute(data, allow_key_clash=True)
 
     def test_compute_preserve_reference_to_self(self):
-        """acre.compute() does not format key references to itself"""
-
+        """acre.compute() does not format key references to itself."""
         data = {
             "PATH": "{PATH}",
             "PYTHONPATH": "x;y/{PYTHONPATH}"
         }
-        data = acre.compute(data)
-        self.assertEqual(data, {
-            "PATH": "{PATH}",
-            "PYTHONPATH": "x;y/{PYTHONPATH}"
-        })
+        # test windows platform
+        with mock.patch("os.pathsep", ";"):
+            data = acre.compute(data)
+            self.assertEqual(data, {
+                "PATH": "{PATH}",
+                "PYTHONPATH": "x;y/{PYTHONPATH}"
+            })
+
+        # test unix platforms
+        with mock.patch("os.pathsep", ":"):
+            data = {
+                "PATH": "{PATH}",
+                "PYTHONPATH": "x:y/{PYTHONPATH}"
+            }
+            data = acre.compute(data)
+            self.assertEqual(data, {
+                "PATH": "{PATH}",
+                "PYTHONPATH": "x:y/{PYTHONPATH}"
+            })
 
     def test_append(self):
         """Append paths of two environments into one."""
-
         data_a = {
-            "A": "A",
-            "B": "B"
+            "A": "A\\a",
+            "B": "B\\b",
+            "C": "C"
         }
         data_b = {
-            "A": "A2",
-            "C": "C2"
+            "A": "A2\\a2",
+            "C": "C",
+            "D": "D2",
         }
 
         # Keep unaltered copies to check afterwards the originals
@@ -148,21 +163,38 @@ class TestDynamicEnvironments(unittest.TestCase):
         _data_a = data_a.copy()
         _data_b = data_b.copy()
 
-        data = acre.append(data_a, data_b)
+        # test windows platform
+        with mock.patch("platform.system", return_value="Windows"):
+            with mock.patch("os.pathsep", ";"):
+                data = acre.append(data_a, data_b)
 
-        self.assertEqual(data, {
-            "A": "A;A2",
-            "B": "B",
-            "C": "C2"
-        })
+                self.assertEqual(data, {
+                    "A": "A\\a;A2\\a2",
+                    "B": "B\\b",
+                    "C": "C",
+                    "D": "D2"
+                })
+
+        # test unix platforms
+        with mock.patch("platform.system", return_value="Linux"):
+            with mock.patch("os.pathsep", ":"):
+                with mock.patch.dict(data_a, {"A": "A/a", "B": "B/b"}):
+                    with mock.patch.dict(data_b, {"A": "A2/a2"}):
+                        data = acre.append(data_a, data_b)
+
+                        self.assertEqual(data, {
+                            "A": "A/a:A2/a2",
+                            "B": "B/b",
+                            "C": "C",
+                            "D": "D2"
+                        })
 
         # Ensure the original dicts are unaltered
         self.assertEqual(data_a, _data_a)
         self.assertEqual(data_b, _data_b)
 
     def test_merge(self):
-        """acre.merge() merges correctly"""
-
+        """acre.merge() merges correctly."""
         data = {
             "A": "a;{A}",
             "B": "b;c;d",
@@ -174,44 +206,131 @@ class TestDynamicEnvironments(unittest.TestCase):
             "C": "D"
         }
 
-        data = acre.merge(data, current_env=environment)
+        # test Windows platform
+        with mock.patch("platform.system", return_value="Windows"):
+            with mock.patch("os.pathsep", ";"):
+                data = acre.merge(data, current_env=environment)
 
-        # Note that C from the environment is not preserved, it's overwritten
-        # by the merge. (To preserve it should have a reference to itself)
-        # See "A"
-        self.assertEqual(data, {
-            "A": "a;A",
-            "B": "b;c;d",
-            "C": "C"
-        })
+                # Note that C from the environment is not preserved,
+                # it's overwritten by the merge. (To preserve it should have
+                # a reference to itself). See "A"
+                self.assertEqual(data, {
+                    "A": "a;A",
+                    "B": "b;c;d",
+                    "C": "C"
+                })
+
+        # test unix platforms
+        with mock.patch("platform.system", return_value="Linux"):
+            with mock.patch("os.pathsep", ":"):
+                data = {
+                    "A": "a:{A}",
+                    "B": "b:c:d",
+                    "C": "C"
+                }
+                data = acre.merge(data, current_env=environment)
+                self.assertEqual(data, {
+                    "A": "a:A",
+                    "B": "b:c:d",
+                    "C": "C"
+                })
 
     def test_merge_formats_references_to_self(self):
-        """acre.merge() correctly formats variables references to itself"""
-
+        """acre.merge() correctly formats variables references to itself."""
         # Skip when not in current environment
-        data = {
-            "PATH": "a;b;{PATH}",
-        }
 
-        merged = acre.merge(data, current_env={})
-        self.assertEqual(merged["PATH"], "a;b;")
+        # test Windows platform
+        with mock.patch("platform.system", return_value="Windows"):
+            with mock.patch("os.pathsep", ";"):
+                data = {
+                    "PATH": "a;b;{PATH}",
+                }
+                merged = acre.merge(data, current_env={})
+                self.assertEqual(merged["PATH"], "a;b;")
+
+        # test unix platforms
+        with mock.patch("platform.system", return_value="Linux"):
+            with mock.patch("os.pathsep", ":"):
+                data = {
+                    "PATH": "a:b:{PATH}",
+                }
+                merged = acre.merge(data, current_env={})
+                self.assertEqual(merged["PATH"], "a:b:")
 
         # Allow merge
-        data = {
-            "PATH": "a;b;{PATH}"
-        }
 
         # Note that on merge the paths are *not* ensured to be unique and
         # *might* end up in the resulting variable more than once.
         # This is expected behavior.
-        merged = acre.merge(data, current_env={"PATH": "b;c;d"})
-        self.assertEqual(merged["PATH"], "a;b;b;c;d")
+
+        # test Windows platform
+        with mock.patch("platform.system", return_value="Windows"):
+            with mock.patch("os.pathsep", ";"):
+                data = {
+                    "PATH": "a;b;{PATH}"
+                }
+
+                merged = acre.merge(data, current_env={"PATH": "b;c;d"})
+                self.assertEqual(merged["PATH"], "a;b;b;c;d")
+
+        # test unix platforms
+        with mock.patch("platform.system", return_value="Linux"):
+            with mock.patch("os.pathsep", ":"):
+                data = {
+                    "PATH": "a:b:{PATH}"
+                }
+
+                merged = acre.merge(data, current_env={"PATH": "b:c:d"})
+                self.assertEqual(merged["PATH"], "a:b:b:c:d")
 
     def test_merge_preserves_current_env(self):
-        """acre.merge() preserves data in original environment"""
-
+        """acre.merge() preserves data in original environment."""
         data = {"A": "a"}
         environment = {"B": "b"}
         result = acre.merge(data, current_env=environment)
 
         self.assertEqual(result["B"], "b")
+
+    def test_cleanup(self):
+        """Test if acre.compute() cleanup function behaves correctly."""
+        data = {
+            "A": "FOO",
+            "B": "{A}",
+            "C": ":0.0",
+            "D": "A;A;B;C",
+            "E": "a\\A;a\\A;B;C",
+            "F": "a\\A;a\\A;b\\B;c\\C",
+            "G": ";;a\\A;b\\B",
+            "H": ";;a;b"
+        }
+        expected = {
+            "A": "FOO",
+            "B": "FOO",
+            "C": ":0.0",
+            "D": "A;A;B;C",
+            "E": "a\\A;a\\A;B;C",
+            "F": "a\\A;b\\B;c\\C",
+            "G": "a\\A;b\\B",
+            "H": ";;a;b",
+        }
+        # test unix platforms
+        with mock.patch("platform.system", return_value="Linux"):
+            with mock.patch("os.pathsep", ":"):
+                data.update({
+                    "D": "A:A:B:C",
+                    "E": "a/A:a/A:B:C",
+                    "F": "a/A:a/A:b/B:c/C",
+                    "G": "::a/A:b/B",
+                    "H": "::a:b"
+                })
+
+                expected.update({
+                    "D": "A:A:B:C",
+                    "E": "a/A:a/A:B:C",
+                    "F": "a/A:b/B:c/C",
+                    "G": "a/A:b/B",
+                    "H": "::a:b"
+                })
+
+                result = acre.compute(data, cleanup=True)
+                self.assertEqual(result, expected)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -52,4 +52,3 @@ class TestTools(unittest.TestCase):
         env = acre.compute(env)
         self.assertEqual(env["MAYA_LOCATION"],
                          "C:/Program Files/Autodesk/Maya2018")
-


### PR DESCRIPTION
## Problem

`acre.append()` has hardcoded `;` as path separator. This unfortunately doesn't work on linux and darwin.

## Solution

This PR fixes that semicolon problem along with few style issues I repaired just because I needed *pycodestyle* to shut up. I also changed tests to include unix path styles. There is also one change in `acre.compute()` cleanup code as that was cleaning environment variables it shouldn't. For example **DISPLAY** variable on linux. Without this variable Qt and other stuff has trouble to work. This variable typically has value like `:0.0` and that triggers cleanup code, removing `:` and resulting in `0.0` and that doesn't work.

This is much bigger problem I was thinking about how to solve - not all environment variables are path and they cannot be treated as such. But how can one tell that it is path?

So I've slighly extended cleanup code that will try to detect paths by finding directory separators in the string. So `foo/bar:bar/baz` is considered as string with paths, but `foo:bar` isn't. This is obviously weak as `foo` can be legitimate path too, but it introduce slightly stricter check. Anyway it is still responsibility of user how he is using cleanup code. This also affects `acre.append()` as it is appending all variables no matter if they are having paths in them or not. So I guess there is warning in my story, maybe obvious - don't use `acre.append()` and `acre.compute()` on whole environment.