### PR TITLE
Fixing formatting of partial references #7

### DIFF
--- a/acre/lib.py
+++ b/acre/lib.py
@@ -1,4 +1,5 @@
 import os
+import re
 import string
 
 from collections import defaultdict, namedtuple
@@ -42,7 +43,18 @@ def partial_format(s, data, missing="{{{key}}}"):
 
     formatter = string.Formatter()
     mapping = FormatDict(**data)
-    return formatter.vformat(s, (), mapping)
+    try:
+        f = formatter.vformat(s, (), mapping)
+    except Exception:
+        r_token = re.compile(r"({.*?})")
+        matches = re.findall(r_token, s)
+        f = s
+        for m in matches:
+            try:
+                f = re.sub(m, m.format(**data), f)
+            except KeyError:
+                continue
+    return f
 
 
 def topological_sort(dependency_pairs):

--- a/tests/test_dynamic_environments.py
+++ b/tests/test_dynamic_environments.py
@@ -131,6 +131,22 @@ class TestDynamicEnvironments(unittest.TestCase):
             "PYTHONPATH": "x;y/{PYTHONPATH}"
         })
 
+    def test_compute_reference_formats(self):
+        """acre.compute() will correctly skip unresolved references."""
+        data = {
+            "A": "a",
+            "B": "{A},b",
+            "C": "{C}",
+            "D": "{D[x]}",
+        }
+        data = acre.compute(data)
+        self.assertEqual(data, {
+            "A": "a",
+            "B": "a,b",
+            "C": "{C}",
+            "D": "{D[x]}"
+        })
+
     def test_append(self):
         """Append paths of two environments into one."""
 


### PR DESCRIPTION
This is fix for formatting partial references formatted in *invalid* way.

Say we have:
```python
data = {"FOO": "bar", "BAZ": "{FOO}", "X": "{Y[z]}"}
```
result of `acre.compute()` should ideally be:

```python
>>> acre.compute(data)
{'FOO': 'bar', 'BAZ': 'bar', 'X': '{Y[z]}'}
```

Although `X` can be legitimate value in environment variable, formatting it will fail because it triggers python formatting function expecting it references list with `z` as indice and indices must be ints.

Solution is to try the original way and if it fails, format each reference separately and if one of them fails, return unformatted value.

Resolves #7 